### PR TITLE
autolink plugin

### DIFF
--- a/docs/_media/plugins/autoLink/autoLink.js
+++ b/docs/_media/plugins/autoLink/autoLink.js
@@ -1,0 +1,13 @@
+function plugin(hook, vm) {
+  hook.beforeEach(function (content) {
+    return content.replace(/(\S+\/\S+)?#(\d+)/gm, (fullDescription, repo, number) => {
+      if (!repo) {
+        repo = "vocascan/" + vm.route.file.split("/")[0];
+      }
+
+      return "[" + fullDescription + "](https://github.com/" + repo + "/pull/" + number + ")";
+    });
+  });
+}
+
+window.$docsify.plugins = [].concat(plugin, window.$docsify.plugins);

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,6 +128,7 @@
 
     <!-- Own plugins -->
     <script src="_media/plugins/countdown/countdown.js"></script>
+    <script src="_media/plugins/autoLink/autoLink.js"></script>
 
     <!-- Prism language support -->
     <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>


### PR DESCRIPTION
This PR adds an github autolink plugin which automatically transforms issue/pr references into clickable links to gh.

Example:
```md
# Welcome to vocascan desktop

With vocascan desktop you can easily learn and manage your vocabulary from your computer.

hello #34 ac (#55) vocascan-server/documentation#234

asf asf #34
``` 
will turn into:
![image](https://user-images.githubusercontent.com/60048565/140298494-f91d34d7-c8c1-4bee-ab79-10dc8e023b2d.png)

This is especially needed for the upcoming changelog im currently working on.
